### PR TITLE
Add % of minblockdimension to dimensions for swizzle operations

### DIFF
--- a/SoulsFormats/Formats/TPF/Headerizer.cs
+++ b/SoulsFormats/Formats/TPF/Headerizer.cs
@@ -709,6 +709,8 @@ namespace SoulsFormats
 
         private static long GetDeswizzleSize(int formatBpp, int width, int height, int minBLockDimension, out int deSwizzWidth, out int deSwizzHeight)
         {
+            width += width % minBLockDimension;
+            height += height % minBLockDimension;
             deSwizzWidth = width < minBLockDimension ? minBLockDimension : width;
             deSwizzHeight = height < minBLockDimension ? minBLockDimension : height;
             int bufferLengthMin = (formatBpp * deSwizzWidth * deSwizzHeight / 8);


### PR DESCRIPTION
This fixes textures that aren't multiples of 32, ie 400x400 resolution