### PR TITLE
Fixes: Unexpected PointType 0 error when reading ER s35_00_0000.mqb

### DIFF
--- a/SoulsFormats/Formats/MQB/CustomData.cs
+++ b/SoulsFormats/Formats/MQB/CustomData.cs
@@ -420,8 +420,9 @@ namespace SoulsFormats
                     br.AssertInt32(0x1C); // Sequence size
                     int pointCount = br.ReadInt32();
                     ValueType = br.ReadEnum32<DataType>();
-                    PointType = br.AssertInt32(1, 2);
-                    br.AssertInt32(PointType == 1 ? 0x10 : 0x18); // Point size
+                    // PointType 0 is only ever used once in ER s35_00_0000.mqb, but otherwise seems identical to PointType 1
+                    PointType = br.AssertInt32(0, 1, 2);
+                    br.AssertInt32((PointType == 0 || PointType == 1) ? 0x10 : 0x18); // Point size
                     int pointsOffset = br.ReadInt32();
                     int valueOffset = br.ReadInt32();
 
@@ -451,7 +452,7 @@ namespace SoulsFormats
                     bw.WriteInt32(Points.Count);
                     bw.WriteUInt32((uint)ValueType);
                     bw.WriteInt32(PointType);
-                    bw.WriteInt32(PointType == 1 ? 0x10 : 0x18);
+                    bw.WriteInt32((PointType == 0 || PointType == 1) ? 0x10 : 0x18);
                     bw.ReserveInt32($"PointsOffset[{customDataIndex}:{sequenceIndex}]");
                     if (ValueType == DataType.Byte || ValueType == DataType.Float || ValueType == DataType.UInt)
                         bw.WriteInt32((int)parentValueOffset + ValueIndex);


### PR DESCRIPTION
## Description

Fixes the following unexpected PointType 0 error when reading ER `s35_00_0000.mqb`.

```
s35_00_0000.mqb Read Int32: 0x0 | Expected: 0x1, 0x2 | Ending position: 0x1C5DFC
```

No sure about the exact difference between type 0 and type 1 Points but type 0 is only ever used in ER `s35_00_0000.mqb` and nowhere else.

The size of this point apparently matches that of type 1 and reading it as type 1 in every other regard seems to fix the reading error. The MBQ object read this way can be successfully round-trip serialized back into the exact same original binary, but we may need to eventually revisit this type once future games start utilizing it more widely.

## Test

Round-trip serialized every ER, AC6 and Sekiro MBQ file as a regression test.
No failures observed, the resulting binaries matched the originals in every case.