### PR TITLE
Fix small mips on long textures on PS3, Bump DrSwizzler nuget

### DIFF
--- a/SoulsFormats/Formats/TPF/Headerizer.cs
+++ b/SoulsFormats/Formats/TPF/Headerizer.cs
@@ -362,8 +362,8 @@ namespace SoulsFormats
                 for (int j = 0; j < mipCount; j++)
                 {
                     int scale = (int)Math.Pow(2, j);
-                    int w = PadTo(finalWidth / scale, 1);
-                    int h = PadTo(finalHeight / scale, 1);
+                    int w = PadTo(finalWidth / scale, pixelBlockSize);
+                    int h = PadTo(finalHeight / scale, pixelBlockSize);
                     long calculatedBufferLength = formatBpp * w * h / 8;
 
                     if (calculatedBufferLength < sourceBytesPerPixelSet)
@@ -402,8 +402,8 @@ namespace SoulsFormats
                 for (int j = 0; j < mipCount; j++)
                 {
                     int scale = (int)Math.Pow(2, j);
-                    int w = PadTo(finalWidth / scale, 1);
-                    int h = PadTo(finalHeight / scale, 1);
+                    int w = PadTo(finalWidth / scale, pixelBlockSize);
+                    int h = PadTo(finalHeight / scale, pixelBlockSize);
                     long calculatedBufferLength = formatBpp * w * h / 8;
 
                     if (calculatedBufferLength < sourceBytesPerPixelSet)

--- a/SoulsFormats/SoulsFormats.csproj
+++ b/SoulsFormats/SoulsFormats.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
-    <PackageReference Include="DrSwizzler" Version="1.0.7" />
+    <PackageReference Include="DrSwizzler" Version="1.0.8" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="ZstdNet" Version="1.4.5" />


### PR DESCRIPTION
Also sets up 360 for the correct sizing, though 360 needs some extra works due to the way the smaller mips get stored