### PR TITLE
Fix for messed up Dark Souls Remastered models

### DIFF
--- a/SoulsFormats/Formats/FLVER/FLVER2/BufferLayout.cs
+++ b/SoulsFormats/Formats/FLVER/FLVER2/BufferLayout.cs
@@ -60,6 +60,36 @@ namespace SoulsFormats
                     structOffset += member.Size;
                 }
             }
+
+            /// <summary>
+            /// Dark Souls Remastered may place tangent layoutMembers for vertex arrays where there aren't any. We need to fix this for them to read correctly.
+            /// </summary>
+            public bool DarkSoulsRemasteredFix()
+            {
+                int normalIndex = -1;
+                for (int i = 0; i < this.Count; i++)
+                {
+                    var lyt = this[i];
+                    switch (lyt.Semantic)
+                    {
+                        case FLVER.LayoutSemantic.Normal:
+                            normalIndex = i;
+                            break;
+                        case FLVER.LayoutSemantic.Tangent:
+                            RemoveAt(i);
+                            return true;
+                    }
+                }
+                //If there's no normal, this probably shouldn't go in either.
+                if (normalIndex == -1)
+                {
+                    return false;
+                }
+
+                FLVER.LayoutMember tangentLayout = new FLVER.LayoutMember(FLVER.LayoutType.Byte4C, FLVER.LayoutSemantic.Tangent, 0, 0);
+                Insert(normalIndex + 1, tangentLayout);
+                return true;
+            }
         }
     }
 }

--- a/SoulsFormats/Formats/FLVER/FLVER2/VertexBuffer.cs
+++ b/SoulsFormats/Formats/FLVER/FLVER2/VertexBuffer.cs
@@ -44,7 +44,20 @@ namespace SoulsFormats
             {
                 BufferLayout layout = layouts[LayoutIndex];
                 if (VertexSize != layout.Size)
-                    throw new InvalidDataException($"Mismatched vertex buffer and buffer layout sizes.");
+                {
+                    //Only try this for DS1
+                    if (header.Version == 0x2000B || header.Version == 0x2000C || header.Version == 0x2000D)
+                    {
+                        if (!layout.DarkSoulsRemasteredFix())
+                        {
+                            throw new InvalidDataException($"Mismatched vertex buffer and buffer layout sizes for Dark Souls Remastered model.");
+                        }
+                    }
+                    else
+                    {
+                        throw new InvalidDataException($"Mismatched vertex buffer and buffer layout sizes.");
+                    }
+                }
 
                 br.StepIn(dataOffset + BufferOffset);
                 {


### PR DESCRIPTION
Dark Souls Remastered models sometimes have messed up vertex layouts that improperly include or don't include a reference to a tangent layout member.

We fix this by adding or removing this as appropriate.