### PR TITLE
DCX CompressionInfo rework

### DIFF
--- a/SoulsFormats/Formats/Binder/BND3/BND3Reader.cs
+++ b/SoulsFormats/Formats/Binder/BND3/BND3Reader.cs
@@ -22,7 +22,7 @@ namespace SoulsFormats
         /// <summary>
         /// Type of compression used, if any.
         /// </summary>
-        public DCX.Type Compression { get; set; }
+        public DCX.CompressionData Compression { get; set; }
 
         /// <summary>
         /// Reads a BND3 from the given path, decompressing if necessary.
@@ -60,7 +60,7 @@ namespace SoulsFormats
 
         private void Read(BinaryReaderEx br)
         {
-            br = SFUtil.GetDecompressedBinaryReader(br, out DCX.Type compression);
+            br = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression);
             Compression = compression;
             Files = BND3.ReadHeader(this, br);
             DataBR = br;

--- a/SoulsFormats/Formats/Binder/BND3/BND3Reader.cs
+++ b/SoulsFormats/Formats/Binder/BND3/BND3Reader.cs
@@ -22,7 +22,7 @@ namespace SoulsFormats
         /// <summary>
         /// Type of compression used, if any.
         /// </summary>
-        public DCX.CompressionData Compression { get; set; }
+        public DCX.CompressionInfo Compression { get; set; }
 
         /// <summary>
         /// Reads a BND3 from the given path, decompressing if necessary.
@@ -60,7 +60,7 @@ namespace SoulsFormats
 
         private void Read(BinaryReaderEx br)
         {
-            br = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression);
+            br = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionInfo compression);
             Compression = compression;
             Files = BND3.ReadHeader(this, br);
             DataBR = br;

--- a/SoulsFormats/Formats/Binder/BND4/BND4Reader.cs
+++ b/SoulsFormats/Formats/Binder/BND4/BND4Reader.cs
@@ -31,7 +31,7 @@ namespace SoulsFormats
         /// <summary>
         /// Type of compression used, if any.
         /// </summary>
-        public DCX.CompressionData Compression { get; set; }
+        public DCX.CompressionInfo Compression { get; set; }
 
         /// <summary>
         /// Reads a BND4 from the given path, decompressing if necessary.
@@ -69,7 +69,7 @@ namespace SoulsFormats
 
         private void Read(BinaryReaderEx br)
         {
-            br = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression);
+            br = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionInfo compression);
             Compression = compression;
             Files = BND4.ReadHeader(this, br);
             DataBR = br;

--- a/SoulsFormats/Formats/Binder/BND4/BND4Reader.cs
+++ b/SoulsFormats/Formats/Binder/BND4/BND4Reader.cs
@@ -31,7 +31,7 @@ namespace SoulsFormats
         /// <summary>
         /// Type of compression used, if any.
         /// </summary>
-        public DCX.Type Compression { get; set; }
+        public DCX.CompressionData Compression { get; set; }
 
         /// <summary>
         /// Reads a BND4 from the given path, decompressing if necessary.
@@ -69,7 +69,7 @@ namespace SoulsFormats
 
         private void Read(BinaryReaderEx br)
         {
-            br = SFUtil.GetDecompressedBinaryReader(br, out DCX.Type compression);
+            br = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression);
             Compression = compression;
             Files = BND4.ReadHeader(this, br);
             DataBR = br;

--- a/SoulsFormats/Formats/Binder/BXF3/BXF3.cs
+++ b/SoulsFormats/Formats/Binder/BXF3/BXF3.cs
@@ -69,8 +69,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdPath))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.Type _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.Type _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
             {
                 return new BXF3(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -86,8 +86,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdPath))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.Type _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.Type _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
             {
                 return new BXF3(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -103,8 +103,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdPath))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtStream, true))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.Type _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.Type _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
             {
                 return new BXF3(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -120,8 +120,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdBytes))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.Type _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.Type _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
             {
                 return new BXF3(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -137,8 +137,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdBytes))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtPath))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.Type _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.Type _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
             {
                 return new BXF3(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -154,8 +154,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdBytes))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtStream, true))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.Type _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.Type _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
             {
                 return new BXF3(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -171,8 +171,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdStream, true))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtStream, true))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.Type _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.Type _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
             {
                 return new BXF3(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -188,8 +188,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdStream, true))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtPath))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.Type _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.Type _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
             {
                 return new BXF3(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -205,8 +205,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdStream, true))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.Type _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.Type _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
             {
                 return new BXF3(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -371,7 +371,7 @@ namespace SoulsFormats
                 }
 
                 using (BinaryReaderEx br = new BinaryReaderEx(false, fs))
-                using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.Type compression))
+                using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
                 {
                     return IsHeader(brd);
                 }
@@ -389,7 +389,7 @@ namespace SoulsFormats
             }
 
             using (BinaryReaderEx br = new BinaryReaderEx(false, bytes))
-            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.Type compression))
+            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
             {
                 return IsHeader(brd);
             }
@@ -406,7 +406,7 @@ namespace SoulsFormats
             }
 
             using (BinaryReaderEx br = new BinaryReaderEx(false, stream, true))
-            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.Type compression))
+            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
             {
                 return IsHeader(brd);
             }
@@ -431,7 +431,7 @@ namespace SoulsFormats
                 }
 
                 using (BinaryReaderEx br = new BinaryReaderEx(false, fs))
-                using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.Type compression))
+                using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
                 {
                     return IsData(brd);
                 }
@@ -449,7 +449,7 @@ namespace SoulsFormats
             }
 
             using (BinaryReaderEx br = new BinaryReaderEx(false, bytes))
-            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.Type compression))
+            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
             {
                 return IsData(brd);
             }
@@ -466,7 +466,7 @@ namespace SoulsFormats
             }
 
             using (BinaryReaderEx br = new BinaryReaderEx(false, stream, true))
-            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.Type compression))
+            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
             {
                 return IsData(brd);
             }

--- a/SoulsFormats/Formats/Binder/BXF3/BXF3.cs
+++ b/SoulsFormats/Formats/Binder/BXF3/BXF3.cs
@@ -69,8 +69,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdPath))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionInfo _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionInfo _))
             {
                 return new BXF3(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -86,8 +86,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdPath))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionInfo _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionInfo _))
             {
                 return new BXF3(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -103,8 +103,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdPath))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtStream, true))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionInfo _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionInfo _))
             {
                 return new BXF3(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -120,8 +120,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdBytes))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionInfo _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionInfo _))
             {
                 return new BXF3(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -137,8 +137,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdBytes))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtPath))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionInfo _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionInfo _))
             {
                 return new BXF3(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -154,8 +154,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdBytes))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtStream, true))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionInfo _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionInfo _))
             {
                 return new BXF3(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -171,8 +171,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdStream, true))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtStream, true))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionInfo _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionInfo _))
             {
                 return new BXF3(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -188,8 +188,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdStream, true))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtPath))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionInfo _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionInfo _))
             {
                 return new BXF3(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -205,8 +205,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdStream, true))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionInfo _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionInfo _))
             {
                 return new BXF3(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -371,7 +371,7 @@ namespace SoulsFormats
                 }
 
                 using (BinaryReaderEx br = new BinaryReaderEx(false, fs))
-                using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
+                using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionInfo compression))
                 {
                     return IsHeader(brd);
                 }
@@ -389,7 +389,7 @@ namespace SoulsFormats
             }
 
             using (BinaryReaderEx br = new BinaryReaderEx(false, bytes))
-            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
+            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionInfo compression))
             {
                 return IsHeader(brd);
             }
@@ -406,7 +406,7 @@ namespace SoulsFormats
             }
 
             using (BinaryReaderEx br = new BinaryReaderEx(false, stream, true))
-            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
+            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionInfo compression))
             {
                 return IsHeader(brd);
             }
@@ -431,7 +431,7 @@ namespace SoulsFormats
                 }
 
                 using (BinaryReaderEx br = new BinaryReaderEx(false, fs))
-                using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
+                using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionInfo compression))
                 {
                     return IsData(brd);
                 }
@@ -449,7 +449,7 @@ namespace SoulsFormats
             }
 
             using (BinaryReaderEx br = new BinaryReaderEx(false, bytes))
-            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
+            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionInfo compression))
             {
                 return IsData(brd);
             }
@@ -466,7 +466,7 @@ namespace SoulsFormats
             }
 
             using (BinaryReaderEx br = new BinaryReaderEx(false, stream, true))
-            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
+            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionInfo compression))
             {
                 return IsData(brd);
             }

--- a/SoulsFormats/Formats/Binder/BXF4/BXF4.cs
+++ b/SoulsFormats/Formats/Binder/BXF4/BXF4.cs
@@ -91,8 +91,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdPath))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionInfo _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionInfo _))
             {
                 return new BXF4(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -108,8 +108,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdPath))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionInfo _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionInfo _))
             {
                 return new BXF4(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -125,8 +125,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdPath))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtStream, true))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionInfo _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionInfo _))
             {
                 return new BXF4(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -142,8 +142,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdBytes))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionInfo _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionInfo _))
             {
                 return new BXF4(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -159,8 +159,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdBytes))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtPath))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionInfo _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionInfo _))
             {
                 return new BXF4(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -176,8 +176,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdBytes))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtStream, true))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionInfo _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionInfo _))
             {
                 return new BXF4(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -193,8 +193,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdStream, true))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtStream, true))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionInfo _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionInfo _))
             {
                 return new BXF4(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -210,8 +210,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdStream, true))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtPath))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionInfo _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionInfo _))
             {
                 return new BXF4(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -227,8 +227,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdStream, true))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionInfo _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionInfo _))
             {
                 return new BXF4(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -467,7 +467,7 @@ namespace SoulsFormats
                 }
 
                 using (BinaryReaderEx br = new BinaryReaderEx(false, fs))
-                using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
+                using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionInfo compression))
                 {
                     return IsHeader(brd);
                 }
@@ -485,7 +485,7 @@ namespace SoulsFormats
             }
 
             using (BinaryReaderEx br = new BinaryReaderEx(false, bytes))
-            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
+            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionInfo compression))
             {
                 return IsHeader(brd);
             }
@@ -502,7 +502,7 @@ namespace SoulsFormats
             }
 
             using (BinaryReaderEx br = new BinaryReaderEx(false, stream, true))
-            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
+            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionInfo compression))
             {
                 return IsHeader(brd);
             }
@@ -526,7 +526,7 @@ namespace SoulsFormats
                 }
 
                 using (BinaryReaderEx br = new BinaryReaderEx(false, fs))
-                using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
+                using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionInfo compression))
                 {
                     return IsData(brd);
                 }
@@ -544,7 +544,7 @@ namespace SoulsFormats
             }
 
             using (BinaryReaderEx br = new BinaryReaderEx(false, bytes))
-            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
+            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionInfo compression))
             {
                 return IsData(brd);
             }
@@ -561,7 +561,7 @@ namespace SoulsFormats
             }
 
             using (BinaryReaderEx br = new BinaryReaderEx(false, stream, true))
-            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
+            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionInfo compression))
             {
                 return IsData(brd);
             }

--- a/SoulsFormats/Formats/Binder/BXF4/BXF4.cs
+++ b/SoulsFormats/Formats/Binder/BXF4/BXF4.cs
@@ -91,8 +91,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdPath))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.Type _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.Type _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
             {
                 return new BXF4(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -108,8 +108,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdPath))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.Type _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.Type _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
             {
                 return new BXF4(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -125,8 +125,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdPath))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtStream, true))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.Type _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.Type _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
             {
                 return new BXF4(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -142,8 +142,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdBytes))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.Type _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.Type _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
             {
                 return new BXF4(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -159,8 +159,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdBytes))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtPath))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.Type _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.Type _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
             {
                 return new BXF4(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -176,8 +176,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdBytes))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtStream, true))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.Type _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.Type _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
             {
                 return new BXF4(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -193,8 +193,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdStream, true))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtStream, true))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.Type _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.Type _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
             {
                 return new BXF4(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -210,8 +210,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdStream, true))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtPath))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.Type _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.Type _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
             {
                 return new BXF4(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -227,8 +227,8 @@ namespace SoulsFormats
         {
             using (BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdStream, true))
             using (BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes))
-            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.Type _))
-            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.Type _))
+            using (BinaryReaderEx bhdReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bhdReader, out DCX.CompressionData _))
+            using (BinaryReaderEx bdtReaderDecompressed = SFUtil.GetDecompressedBinaryReader(bdtReader, out DCX.CompressionData _))
             {
                 return new BXF4(bhdReaderDecompressed, bdtReaderDecompressed);
             }
@@ -467,7 +467,7 @@ namespace SoulsFormats
                 }
 
                 using (BinaryReaderEx br = new BinaryReaderEx(false, fs))
-                using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.Type compression))
+                using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
                 {
                     return IsHeader(brd);
                 }
@@ -485,7 +485,7 @@ namespace SoulsFormats
             }
 
             using (BinaryReaderEx br = new BinaryReaderEx(false, bytes))
-            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.Type compression))
+            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
             {
                 return IsHeader(brd);
             }
@@ -502,7 +502,7 @@ namespace SoulsFormats
             }
 
             using (BinaryReaderEx br = new BinaryReaderEx(false, stream, true))
-            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.Type compression))
+            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
             {
                 return IsHeader(brd);
             }
@@ -526,7 +526,7 @@ namespace SoulsFormats
                 }
 
                 using (BinaryReaderEx br = new BinaryReaderEx(false, fs))
-                using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.Type compression))
+                using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
                 {
                     return IsData(brd);
                 }
@@ -544,7 +544,7 @@ namespace SoulsFormats
             }
 
             using (BinaryReaderEx br = new BinaryReaderEx(false, bytes))
-            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.Type compression))
+            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
             {
                 return IsData(brd);
             }
@@ -561,7 +561,7 @@ namespace SoulsFormats
             }
 
             using (BinaryReaderEx br = new BinaryReaderEx(false, stream, true))
-            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.Type compression))
+            using (BinaryReaderEx brd = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
             {
                 return IsData(brd);
             }

--- a/SoulsFormats/Formats/Binder/BinderFile.cs
+++ b/SoulsFormats/Formats/Binder/BinderFile.cs
@@ -61,7 +61,7 @@ namespace SoulsFormats
             ID = id;
             Name = name;
             Bytes = bytes;
-            CompressionData = new DCX.CompressionData(DCX.Type.Zlib);
+            CompressionData = new DCX.ZlibCompressionData();
         }
 
         /// <summary>

--- a/SoulsFormats/Formats/Binder/BinderFile.cs
+++ b/SoulsFormats/Formats/Binder/BinderFile.cs
@@ -30,7 +30,7 @@ namespace SoulsFormats
         /// <summary>
         /// If compressed, information about the compression in use.
         /// </summary>
-        public DCX.CompressionData CompressionData { get; set; }
+        public DCX.CompressionInfo CompressionInfo { get; set; }
 
         /// <summary>
         /// Creates a new file with 0 bytes and no ID or name.
@@ -61,7 +61,7 @@ namespace SoulsFormats
             ID = id;
             Name = name;
             Bytes = bytes;
-            CompressionData = new DCX.ZlibCompressionData();
+            CompressionInfo = new DCX.ZlibCompressionInfo();
         }
 
         /// <summary>

--- a/SoulsFormats/Formats/Binder/BinderFile.cs
+++ b/SoulsFormats/Formats/Binder/BinderFile.cs
@@ -28,9 +28,9 @@ namespace SoulsFormats
         public byte[] Bytes { get; set; }
 
         /// <summary>
-        /// If compressed, which type of compression to use.
+        /// If compressed, information about the compression in use.
         /// </summary>
-        public DCX.Type CompressionType { get; set; }
+        public DCX.CompressionData CompressionData { get; set; }
 
         /// <summary>
         /// Creates a new file with 0 bytes and no ID or name.
@@ -61,7 +61,7 @@ namespace SoulsFormats
             ID = id;
             Name = name;
             Bytes = bytes;
-            CompressionType = DCX.Type.Zlib;
+            CompressionData = new DCX.CompressionData(DCX.Type.Zlib);
         }
 
         /// <summary>

--- a/SoulsFormats/Formats/Binder/BinderFileHeader.cs
+++ b/SoulsFormats/Formats/Binder/BinderFileHeader.cs
@@ -62,7 +62,7 @@ namespace SoulsFormats
             Flags = flags;
             ID = id;
             Name = name;
-            Compression = new DCX.CompressionData(DCX.Type.Zlib);
+            Compression = new DCX.ZlibCompressionData();
             CompressedSize = compressedSize;
             UncompressedSize = uncompressedSize;
             DataOffset = dataOffset;
@@ -158,7 +158,7 @@ namespace SoulsFormats
         internal BinderFile ReadFileData(BinaryReaderEx br)
         {
             byte[] bytes;
-            DCX.CompressionData compressionData = new DCX.CompressionData(DCX.Type.Zlib);
+            DCX.CompressionData compressionData = new DCX.ZlibCompressionData();
             if (IsCompressed(Flags))
             {
                 bytes = br.GetBytes(DataOffset, (int)CompressedSize);

--- a/SoulsFormats/Formats/Binder/BinderFileHeader.cs
+++ b/SoulsFormats/Formats/Binder/BinderFileHeader.cs
@@ -25,7 +25,7 @@ namespace SoulsFormats
         /// <summary>
         /// If compressed, which type of compression to use.
         /// </summary>
-        public DCX.Type CompressionType { get; set; }
+        public DCX.CompressionData Compression { get; set; }
 
         /// <summary>
         /// Size of the file after compression (or just the size of the file, if not compressed). Do not modify unless you know what you're doing.
@@ -54,7 +54,7 @@ namespace SoulsFormats
 
         internal BinderFileHeader(BinderFile file) : this(file.Flags, file.ID, file.Name, -1, -1, -1)
         {
-            CompressionType = file.CompressionType;
+            Compression = file.CompressionData;
         }
 
         private BinderFileHeader(FileFlags flags, int id, string name, long compressedSize, long uncompressedSize, long dataOffset)
@@ -62,7 +62,7 @@ namespace SoulsFormats
             Flags = flags;
             ID = id;
             Name = name;
-            CompressionType = DCX.Type.Zlib;
+            Compression = new DCX.CompressionData(DCX.Type.Zlib);
             CompressedSize = compressedSize;
             UncompressedSize = uncompressedSize;
             DataOffset = dataOffset;
@@ -158,11 +158,11 @@ namespace SoulsFormats
         internal BinderFile ReadFileData(BinaryReaderEx br)
         {
             byte[] bytes;
-            DCX.Type compressionType = DCX.Type.Zlib;
+            DCX.CompressionData compressionData = new DCX.CompressionData(DCX.Type.Zlib);
             if (IsCompressed(Flags))
             {
                 bytes = br.GetBytes(DataOffset, (int)CompressedSize);
-                bytes = DCX.Decompress(bytes, out compressionType);
+                bytes = DCX.Decompress(bytes, out compressionData);
             }
             else
             {
@@ -171,7 +171,7 @@ namespace SoulsFormats
 
             return new BinderFile(Flags, ID, Name, bytes)
             {
-                CompressionType = compressionType,
+                CompressionData = compressionData,
             };
         }
 
@@ -239,7 +239,7 @@ namespace SoulsFormats
             UncompressedSize = bytes.LongLength;
             if (IsCompressed(Flags))
             {
-                byte[] compressed = DCX.Compress(bytes, CompressionType);
+                byte[] compressed = DCX.Compress(bytes, Compression);
                 CompressedSize = compressed.LongLength;
                 bw.WriteBytes(compressed);
             }

--- a/SoulsFormats/Formats/Binder/BinderFileHeader.cs
+++ b/SoulsFormats/Formats/Binder/BinderFileHeader.cs
@@ -25,7 +25,7 @@ namespace SoulsFormats
         /// <summary>
         /// If compressed, which type of compression to use.
         /// </summary>
-        public DCX.CompressionData Compression { get; set; }
+        public DCX.CompressionInfo Compression { get; set; }
 
         /// <summary>
         /// Size of the file after compression (or just the size of the file, if not compressed). Do not modify unless you know what you're doing.
@@ -54,7 +54,7 @@ namespace SoulsFormats
 
         internal BinderFileHeader(BinderFile file) : this(file.Flags, file.ID, file.Name, -1, -1, -1)
         {
-            Compression = file.CompressionData;
+            Compression = file.CompressionInfo;
         }
 
         private BinderFileHeader(FileFlags flags, int id, string name, long compressedSize, long uncompressedSize, long dataOffset)
@@ -62,7 +62,7 @@ namespace SoulsFormats
             Flags = flags;
             ID = id;
             Name = name;
-            Compression = new DCX.ZlibCompressionData();
+            Compression = new DCX.ZlibCompressionInfo();
             CompressedSize = compressedSize;
             UncompressedSize = uncompressedSize;
             DataOffset = dataOffset;
@@ -158,11 +158,11 @@ namespace SoulsFormats
         internal BinderFile ReadFileData(BinaryReaderEx br)
         {
             byte[] bytes;
-            DCX.CompressionData compressionData = new DCX.ZlibCompressionData();
+            DCX.CompressionInfo compressionInfo = new DCX.ZlibCompressionInfo();
             if (IsCompressed(Flags))
             {
                 bytes = br.GetBytes(DataOffset, (int)CompressedSize);
-                bytes = DCX.Decompress(bytes, out compressionData);
+                bytes = DCX.Decompress(bytes, out compressionInfo);
             }
             else
             {
@@ -171,7 +171,7 @@ namespace SoulsFormats
 
             return new BinderFile(Flags, ID, Name, bytes)
             {
-                CompressionData = compressionData,
+                CompressionInfo = compressionInfo,
             };
         }
 

--- a/SoulsFormats/Formats/DCX.cs
+++ b/SoulsFormats/Formats/DCX.cs
@@ -859,39 +859,49 @@ namespace SoulsFormats
             Type Type { get; }
         }
 
+        [Serializable]
         public struct UnkCompressionData : CompressionData
         {
             [XmlText]
             public Type Type => Type.Unknown;
         }
 
+        [Serializable]
         public struct NoCompressionData : CompressionData
         {
             [XmlText]
             public Type Type => Type.None;
         }
 
+        [Serializable]
         public struct DcpDfltCompressionData : CompressionData
         {
             [XmlText]
             public Type Type => Type.DCP_DFLT;
         }
+        
+        [Serializable]
         public struct DcpEdgeCompressionData : CompressionData
         {
             [XmlText]
             public Type Type => Type.DCP_EDGE;
         }
+        
+        [Serializable]
         public struct ZlibCompressionData : CompressionData
         {
             [XmlText]
             public Type Type => Type.Zlib;
         }
+        
+        [Serializable]
         public struct DcxEdgeCompressionData : CompressionData
         {
             [XmlText]
             public Type Type => Type.DCX_EDGE;
         }
 
+        [Serializable]
         public struct DcxDfltCompressionData : CompressionData
         {
             [XmlText]
@@ -917,6 +927,7 @@ namespace SoulsFormats
             }
         }
         
+        [Serializable]
         public struct DcxKrakCompressionData : CompressionData
         {
             [XmlText]
@@ -931,6 +942,7 @@ namespace SoulsFormats
             }
         }
         
+        [Serializable]
         public struct DcxZstdCompressionData : CompressionData
         {
             [XmlText]

--- a/SoulsFormats/Formats/DCX.cs
+++ b/SoulsFormats/Formats/DCX.cs
@@ -901,6 +901,14 @@ namespace SoulsFormats
             public Type Type => Type.DCX_EDGE;
         }
 
+        public enum DfltCompressionPreset
+        {
+            DCX_DFLT_10000_24_9,
+            DCX_DFLT_10000_44_9,
+            DCX_DFLT_11000_44_8,
+            DCX_DFLT_11000_44_9,
+            DCX_DFLT_11000_44_9_15
+        }
         [Serializable]
         public struct DcxDfltCompressionData : CompressionData
         {
@@ -925,8 +933,57 @@ namespace SoulsFormats
                 Unk30 = unk30;
                 Unk38 = unk38;
             }
+
+            public DcxDfltCompressionData(DfltCompressionPreset preset)
+            {
+                switch (preset)
+                {
+                    case DfltCompressionPreset.DCX_DFLT_10000_24_9:
+                        Unk04 = 0x10000;
+                        Unk10 = 0x24;
+                        Unk14 = 0x2C;
+                        Unk30 = 9;
+                        Unk38 = 0;
+                        break;
+                    case DfltCompressionPreset.DCX_DFLT_10000_44_9:
+                        Unk04 = 0x10000;
+                        Unk10 = 0x44;
+                        Unk14 = 0x4C;
+                        Unk30 = 9;
+                        Unk38 = 0;
+                        break;
+                    case DfltCompressionPreset.DCX_DFLT_11000_44_8:
+                        Unk04 = 0x11000;
+                        Unk10 = 0x44;
+                        Unk14 = 0x4C;
+                        Unk30 = 8;
+                        Unk38 = 0;
+                        break;
+                    case DfltCompressionPreset.DCX_DFLT_11000_44_9:
+                        Unk04 = 0x11000;
+                        Unk10 = 0x44;
+                        Unk14 = 0x4C;
+                        Unk30 = 9;
+                        Unk38 = 0;
+                        break;
+                    case DfltCompressionPreset.DCX_DFLT_11000_44_9_15:
+                        Unk04 = 0x11000;
+                        Unk10 = 0x44;
+                        Unk14 = 0x4C;
+                        Unk30 = 9;
+                        Unk38 = 15;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(preset), preset, null);
+                }
+            }
         }
-        
+
+        public enum KrakCompressionPreset
+        {
+            EldenRing,
+            ArmoredCore6
+        }
         [Serializable]
         public struct DcxKrakCompressionData : CompressionData
         {
@@ -939,6 +996,21 @@ namespace SoulsFormats
             public DcxKrakCompressionData (byte compressionLevel)
             {
                 CompressionLevel = compressionLevel;
+            }
+
+            public DcxKrakCompressionData(KrakCompressionPreset preset)
+            {
+                switch (preset)
+                {
+                    case KrakCompressionPreset.EldenRing:
+                        CompressionLevel = 6;
+                        break;
+                    case KrakCompressionPreset.ArmoredCore6:
+                        CompressionLevel = 9;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(preset), preset, null);
+                }
             }
         }
         

--- a/SoulsFormats/Formats/DCX.cs
+++ b/SoulsFormats/Formats/DCX.cs
@@ -2,6 +2,7 @@
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Xml.Serialization;
 using Org.BouncyCastle.Security;
 
 namespace SoulsFormats
@@ -854,43 +855,56 @@ namespace SoulsFormats
 
         public interface CompressionData
         {
+            [XmlText]
             Type Type { get; }
         }
 
         public struct UnkCompressionData : CompressionData
         {
+            [XmlText]
             public Type Type => Type.Unknown;
         }
 
         public struct NoCompressionData : CompressionData
         {
+            [XmlText]
             public Type Type => Type.None;
         }
 
         public struct DcpDfltCompressionData : CompressionData
         {
+            [XmlText]
             public Type Type => Type.DCP_DFLT;
         }
         public struct DcpEdgeCompressionData : CompressionData
         {
+            [XmlText]
             public Type Type => Type.DCP_EDGE;
         }
         public struct ZlibCompressionData : CompressionData
         {
+            [XmlText]
             public Type Type => Type.Zlib;
         }
         public struct DcxEdgeCompressionData : CompressionData
         {
+            [XmlText]
             public Type Type => Type.DCX_EDGE;
         }
 
         public struct DcxDfltCompressionData : CompressionData
         {
+            [XmlText]
             public Type Type => Type.DCX_DFLT;
+            [XmlAttribute]
             public int Unk04 { get; }
+            [XmlAttribute]
             public int Unk10 { get; }
+            [XmlAttribute]
             public int Unk14 { get; }
+            [XmlAttribute]
             public byte Unk30 { get; }
+            [XmlAttribute]
             public byte Unk38 { get; }
 
             public DcxDfltCompressionData(int unk04, int unk10, int unk14, byte unk30, byte unk38)
@@ -905,7 +919,10 @@ namespace SoulsFormats
         
         public struct DcxKrakCompressionData : CompressionData
         {
+            [XmlText]
             public Type Type => Type.DCX_KRAK;
+            
+            [XmlAttribute]
             public byte CompressionLevel { get; }
 
             public DcxKrakCompressionData (byte compressionLevel)
@@ -916,6 +933,7 @@ namespace SoulsFormats
         
         public struct DcxZstdCompressionData : CompressionData
         {
+            [XmlText]
             public Type Type => Type.DCX_ZSTD;
         }
     }

--- a/SoulsFormats/Formats/DRB/DRB.cs
+++ b/SoulsFormats/Formats/DRB/DRB.cs
@@ -781,7 +781,7 @@ namespace SoulsFormats
         /// <summary>
         /// The type of DCX compression to be used when writing.
         /// </summary>
-        public DCX.CompressionData Compression = new DCX.CompressionData(DCX.Type.None);
+        public DCX.CompressionData Compression = new DCX.NoCompressionData();
 
         /// <summary>
         /// Returns true if the bytes appear to be a DRB.

--- a/SoulsFormats/Formats/DRB/DRB.cs
+++ b/SoulsFormats/Formats/DRB/DRB.cs
@@ -781,7 +781,7 @@ namespace SoulsFormats
         /// <summary>
         /// The type of DCX compression to be used when writing.
         /// </summary>
-        public DCX.Type Compression = DCX.Type.None;
+        public DCX.CompressionData Compression = new DCX.CompressionData(DCX.Type.None);
 
         /// <summary>
         /// Returns true if the bytes appear to be a DRB.
@@ -840,9 +840,9 @@ namespace SoulsFormats
         /// <summary>
         /// Writes file data to a BinaryWriterEx, compressing it afterwards if specified.
         /// </summary>
-        private void Write(BinaryWriterEx bw, DCX.Type compression)
+        private void Write(BinaryWriterEx bw, DCX.CompressionData compression)
         {
-            if (compression == DCX.Type.None)
+            if (compression.Type == DCX.Type.None)
             {
                 Write(bw);
             }
@@ -866,7 +866,7 @@ namespace SoulsFormats
         /// <summary>
         /// Writes the file to an array of bytes, compressing it as specified.
         /// </summary>
-        public byte[] Write(DCX.Type compression)
+        public byte[] Write(DCX.CompressionData compression)
         {
             BinaryWriterEx bw = new BinaryWriterEx(false);
             Write(bw, compression);
@@ -884,7 +884,7 @@ namespace SoulsFormats
         /// <summary>
         /// Writes the file to the specified path, compressing it as specified.
         /// </summary>
-        public void Write(string path, DCX.Type compression)
+        public void Write(string path, DCX.CompressionData compression)
         {
             using (FileStream stream = File.Create(path))
             {

--- a/SoulsFormats/Formats/DRB/DRB.cs
+++ b/SoulsFormats/Formats/DRB/DRB.cs
@@ -781,7 +781,7 @@ namespace SoulsFormats
         /// <summary>
         /// The type of DCX compression to be used when writing.
         /// </summary>
-        public DCX.CompressionData Compression = new DCX.NoCompressionData();
+        public DCX.CompressionInfo Compression = new DCX.NoCompressionInfo();
 
         /// <summary>
         /// Returns true if the bytes appear to be a DRB.
@@ -840,7 +840,7 @@ namespace SoulsFormats
         /// <summary>
         /// Writes file data to a BinaryWriterEx, compressing it afterwards if specified.
         /// </summary>
-        private void Write(BinaryWriterEx bw, DCX.CompressionData compression)
+        private void Write(BinaryWriterEx bw, DCX.CompressionInfo compression)
         {
             if (compression.Type == DCX.Type.None)
             {
@@ -866,7 +866,7 @@ namespace SoulsFormats
         /// <summary>
         /// Writes the file to an array of bytes, compressing it as specified.
         /// </summary>
-        public byte[] Write(DCX.CompressionData compression)
+        public byte[] Write(DCX.CompressionInfo compression)
         {
             BinaryWriterEx bw = new BinaryWriterEx(false);
             Write(bw, compression);
@@ -884,7 +884,7 @@ namespace SoulsFormats
         /// <summary>
         /// Writes the file to the specified path, compressing it as specified.
         /// </summary>
-        public void Write(string path, DCX.CompressionData compression)
+        public void Write(string path, DCX.CompressionInfo compression)
         {
             using (FileStream stream = File.Create(path))
             {

--- a/SoulsFormats/Formats/TPF/TPF.cs
+++ b/SoulsFormats/Formats/TPF/TPF.cs
@@ -316,9 +316,9 @@ namespace SoulsFormats
                 Bytes = br.GetBytes(fileOffset, fileSize);
                 if (Flags1 == 2 || Flags1 == 3)
                 {
-                    Bytes = DCX.Decompress(Bytes, out DCX.Type type);
-                    if (type != DCX.Type.DCP_EDGE)
-                        throw new NotImplementedException($"TPF compression is expected to be DCP_EDGE, but it was {type}");
+                    Bytes = DCX.Decompress(Bytes, out DCX.CompressionData compression);
+                    if (compression.Type != DCX.Type.DCP_EDGE)
+                        throw new InvalidDataException($"TPF compression is expected to be DCP_EDGE, but it was {compression.Type}");
                 }
                 //Cubemap fix
                 //Check if this is a DX10 FourCC, check if it's a cubemap
@@ -406,7 +406,7 @@ namespace SoulsFormats
 
                 byte[] bytes = Bytes;
                 if (Flags1 == 2 || Flags1 == 3)
-                    bytes = DCX.Compress(bytes, DCX.Type.DCP_EDGE);
+                    bytes = DCX.Compress(bytes, new DCX.CompressionData(DCX.Type.DCP_EDGE));
 
                 bw.FillInt32($"FileSize{index}", bytes.Length);
                 bw.WriteBytes(bytes);

--- a/SoulsFormats/Formats/TPF/TPF.cs
+++ b/SoulsFormats/Formats/TPF/TPF.cs
@@ -316,7 +316,7 @@ namespace SoulsFormats
                 Bytes = br.GetBytes(fileOffset, fileSize);
                 if (Flags1 == 2 || Flags1 == 3)
                 {
-                    Bytes = DCX.Decompress(Bytes, out DCX.CompressionData compression);
+                    Bytes = DCX.Decompress(Bytes, out DCX.CompressionInfo compression);
                     if (compression.Type != DCX.Type.DCP_EDGE)
                         throw new InvalidDataException($"TPF compression is expected to be DCP_EDGE, but it was {compression.Type}");
                 }
@@ -406,7 +406,7 @@ namespace SoulsFormats
 
                 byte[] bytes = Bytes;
                 if (Flags1 == 2 || Flags1 == 3)
-                    bytes = DCX.Compress(bytes, new DCX.DcpEdgeCompressionData());
+                    bytes = DCX.Compress(bytes, new DCX.DcpEdgeCompressionInfo());
 
                 bw.FillInt32($"FileSize{index}", bytes.Length);
                 bw.WriteBytes(bytes);

--- a/SoulsFormats/Formats/TPF/TPF.cs
+++ b/SoulsFormats/Formats/TPF/TPF.cs
@@ -406,7 +406,7 @@ namespace SoulsFormats
 
                 byte[] bytes = Bytes;
                 if (Flags1 == 2 || Flags1 == 3)
-                    bytes = DCX.Compress(bytes, new DCX.CompressionData(DCX.Type.DCP_EDGE));
+                    bytes = DCX.Compress(bytes, new DCX.DcpEdgeCompressionData());
 
                 bw.FillInt32($"FileSize{index}", bytes.Length);
                 bw.WriteBytes(bytes);

--- a/SoulsFormats/Utilities/Formats/ISoulsFile.cs
+++ b/SoulsFormats/Utilities/Formats/ISoulsFile.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// The compression to use if none is specified.
         /// </summary>
-        DCX.Type Compression { get; set; }
+        DCX.CompressionData Compression { get; set; }
 
         /// <summary>
         /// Writes the file to an array of bytes using the stored compression type.
@@ -18,7 +18,7 @@
         /// <summary>
         /// Writes the file to an array of bytes using the given compression type.
         /// </summary>
-        byte[] Write(DCX.Type compression);
+        byte[] Write(DCX.CompressionData compression);
 
         /// <summary>
         /// Writes the file to disk using the stored compression type.
@@ -28,6 +28,6 @@
         /// <summary>
         /// Writes the file to disk using the given compression type.
         /// </summary>
-        void Write(string path, DCX.Type compression);
+        void Write(string path, DCX.CompressionData compression);
     }
 }

--- a/SoulsFormats/Utilities/Formats/ISoulsFile.cs
+++ b/SoulsFormats/Utilities/Formats/ISoulsFile.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// The compression to use if none is specified.
         /// </summary>
-        DCX.CompressionData Compression { get; set; }
+        DCX.CompressionInfo Compression { get; set; }
 
         /// <summary>
         /// Writes the file to an array of bytes using the stored compression type.
@@ -18,7 +18,7 @@
         /// <summary>
         /// Writes the file to an array of bytes using the given compression type.
         /// </summary>
-        byte[] Write(DCX.CompressionData compression);
+        byte[] Write(DCX.CompressionInfo compression);
 
         /// <summary>
         /// Writes the file to disk using the stored compression type.
@@ -28,6 +28,6 @@
         /// <summary>
         /// Writes the file to disk using the given compression type.
         /// </summary>
-        void Write(string path, DCX.CompressionData compression);
+        void Write(string path, DCX.CompressionInfo compression);
     }
 }

--- a/SoulsFormats/Utilities/Formats/SoulsFile.cs
+++ b/SoulsFormats/Utilities/Formats/SoulsFile.cs
@@ -12,7 +12,7 @@ namespace SoulsFormats
         /// <summary>
         /// The type of DCX compression to be used when writing.
         /// </summary>
-        [XmlElement]
+        [XmlIgnore]
         public DCX.CompressionData Compression { get; set; } = new DCX.NoCompressionData();
 
         #region Is

--- a/SoulsFormats/Utilities/Formats/SoulsFile.cs
+++ b/SoulsFormats/Utilities/Formats/SoulsFile.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Xml.Serialization;
 
 namespace SoulsFormats
 {
@@ -11,6 +12,7 @@ namespace SoulsFormats
         /// <summary>
         /// The type of DCX compression to be used when writing.
         /// </summary>
+        [XmlElement]
         public DCX.CompressionData Compression { get; set; } = new DCX.NoCompressionData();
 
         #region Is

--- a/SoulsFormats/Utilities/Formats/SoulsFile.cs
+++ b/SoulsFormats/Utilities/Formats/SoulsFile.cs
@@ -13,7 +13,7 @@ namespace SoulsFormats
         /// The type of DCX compression to be used when writing.
         /// </summary>
         [XmlIgnore]
-        public DCX.CompressionData Compression { get; set; } = new DCX.NoCompressionData();
+        public DCX.CompressionInfo Compression { get; set; } = new DCX.NoCompressionInfo();
 
         #region Is
 
@@ -115,7 +115,7 @@ namespace SoulsFormats
 
             stream.Position = 0; 
             using (BinaryReaderEx br = new BinaryReaderEx(false, stream, true))
-            using (BinaryReaderEx dbr = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
+            using (BinaryReaderEx dbr = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionInfo compression))
             {
                 TFormat file = new TFormat();
                 file.Compression = compression;
@@ -130,7 +130,7 @@ namespace SoulsFormats
         public static TFormat Read(byte[] bytes)
         {
             using (BinaryReaderEx br = new BinaryReaderEx(false, bytes))
-            using (BinaryReaderEx dbr = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
+            using (BinaryReaderEx dbr = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionInfo compression))
             {
                 TFormat file = new TFormat();
                 file.Compression = compression;
@@ -146,7 +146,7 @@ namespace SoulsFormats
         {
             using (FileStream stream = File.OpenRead(path))
             using (BinaryReaderEx br = new BinaryReaderEx(false, stream, true))
-            using (BinaryReaderEx dbr = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
+            using (BinaryReaderEx dbr = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionInfo compression))
             {
                 TFormat file = new TFormat();
                 file.Compression = compression;
@@ -164,7 +164,7 @@ namespace SoulsFormats
         /// </summary>
         private static bool IsReadInternal(BinaryReaderEx br, out TFormat file)
         {
-            using (BinaryReaderEx dbr = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
+            using (BinaryReaderEx dbr = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionInfo compression))
             {
                 var test = new TFormat();
                 if (test.Is(dbr))
@@ -246,7 +246,7 @@ namespace SoulsFormats
         /// <summary>
         /// Writes file data to a stream, compressing it afterwards if specified.
         /// </summary>
-        private void Write(BinaryWriterEx bw, DCX.CompressionData compression)
+        private void Write(BinaryWriterEx bw, DCX.CompressionInfo compression)
         {
             if (compression.Type == DCX.Type.None)
             {
@@ -274,7 +274,7 @@ namespace SoulsFormats
         /// <summary>
         /// Writes the file to an array of bytes, compressing it as specified.
         /// </summary>
-        public byte[] Write(DCX.CompressionData compression)
+        public byte[] Write(DCX.CompressionInfo compression)
         {
             if (!Validate(out Exception ex))
                 throw ex;
@@ -297,7 +297,7 @@ namespace SoulsFormats
         /// <summary>
         /// Writes the file to the specified path, compressing it as specified.
         /// </summary>
-        public void Write(string path, DCX.CompressionData compression)
+        public void Write(string path, DCX.CompressionInfo compression)
         {
             if (!Validate(out Exception ex))
                 throw ex;

--- a/SoulsFormats/Utilities/Formats/SoulsFile.cs
+++ b/SoulsFormats/Utilities/Formats/SoulsFile.cs
@@ -11,7 +11,7 @@ namespace SoulsFormats
         /// <summary>
         /// The type of DCX compression to be used when writing.
         /// </summary>
-        public DCX.CompressionData Compression { get; set; } = new DCX.CompressionData(DCX.Type.None);
+        public DCX.CompressionData Compression { get; set; } = new DCX.NoCompressionData();
 
         #region Is
 

--- a/SoulsFormats/Utilities/Formats/SoulsFile.cs
+++ b/SoulsFormats/Utilities/Formats/SoulsFile.cs
@@ -11,7 +11,7 @@ namespace SoulsFormats
         /// <summary>
         /// The type of DCX compression to be used when writing.
         /// </summary>
-        public DCX.Type Compression { get; set; } = DCX.Type.None;
+        public DCX.CompressionData Compression { get; set; } = new DCX.CompressionData(DCX.Type.None);
 
         #region Is
 
@@ -113,7 +113,7 @@ namespace SoulsFormats
 
             stream.Position = 0; 
             using (BinaryReaderEx br = new BinaryReaderEx(false, stream, true))
-            using (BinaryReaderEx dbr = SFUtil.GetDecompressedBinaryReader(br, out DCX.Type compression))
+            using (BinaryReaderEx dbr = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
             {
                 TFormat file = new TFormat();
                 file.Compression = compression;
@@ -128,7 +128,7 @@ namespace SoulsFormats
         public static TFormat Read(byte[] bytes)
         {
             using (BinaryReaderEx br = new BinaryReaderEx(false, bytes))
-            using (BinaryReaderEx dbr = SFUtil.GetDecompressedBinaryReader(br, out DCX.Type compression))
+            using (BinaryReaderEx dbr = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
             {
                 TFormat file = new TFormat();
                 file.Compression = compression;
@@ -144,7 +144,7 @@ namespace SoulsFormats
         {
             using (FileStream stream = File.OpenRead(path))
             using (BinaryReaderEx br = new BinaryReaderEx(false, stream, true))
-            using (BinaryReaderEx dbr = SFUtil.GetDecompressedBinaryReader(br, out DCX.Type compression))
+            using (BinaryReaderEx dbr = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
             {
                 TFormat file = new TFormat();
                 file.Compression = compression;
@@ -162,7 +162,7 @@ namespace SoulsFormats
         /// </summary>
         private static bool IsReadInternal(BinaryReaderEx br, out TFormat file)
         {
-            using (BinaryReaderEx dbr = SFUtil.GetDecompressedBinaryReader(br, out DCX.Type compression))
+            using (BinaryReaderEx dbr = SFUtil.GetDecompressedBinaryReader(br, out DCX.CompressionData compression))
             {
                 var test = new TFormat();
                 if (test.Is(dbr))
@@ -244,9 +244,9 @@ namespace SoulsFormats
         /// <summary>
         /// Writes file data to a stream, compressing it afterwards if specified.
         /// </summary>
-        private void Write(BinaryWriterEx bw, DCX.Type compression)
+        private void Write(BinaryWriterEx bw, DCX.CompressionData compression)
         {
-            if (compression == DCX.Type.None)
+            if (compression.Type == DCX.Type.None)
             {
                 Write(bw);
             }
@@ -272,7 +272,7 @@ namespace SoulsFormats
         /// <summary>
         /// Writes the file to an array of bytes, compressing it as specified.
         /// </summary>
-        public byte[] Write(DCX.Type compression)
+        public byte[] Write(DCX.CompressionData compression)
         {
             if (!Validate(out Exception ex))
                 throw ex;
@@ -295,7 +295,7 @@ namespace SoulsFormats
         /// <summary>
         /// Writes the file to the specified path, compressing it as specified.
         /// </summary>
-        public void Write(string path, DCX.Type compression)
+        public void Write(string path, DCX.CompressionData compression)
         {
             if (!Validate(out Exception ex))
                 throw ex;

--- a/SoulsFormats/Utilities/SFUtil.cs
+++ b/SoulsFormats/Utilities/SFUtil.cs
@@ -11,7 +11,7 @@ namespace SoulsFormats
         /// <summary>
         /// Decompresses data and returns a new BinaryReaderEx if necessary.
         /// </summary>
-        public static BinaryReaderEx GetDecompressedBinaryReader(BinaryReaderEx br, out DCX.CompressionData compression)
+        public static BinaryReaderEx GetDecompressedBinaryReader(BinaryReaderEx br, out DCX.CompressionInfo compression)
         {
             if (DCX.Is(br))
             {
@@ -20,7 +20,7 @@ namespace SoulsFormats
             }
             else
             {
-                compression = new DCX.NoCompressionData();
+                compression = new DCX.NoCompressionInfo();
                 return br;
             }
         }

--- a/SoulsFormats/Utilities/SFUtil.cs
+++ b/SoulsFormats/Utilities/SFUtil.cs
@@ -11,7 +11,7 @@ namespace SoulsFormats
         /// <summary>
         /// Decompresses data and returns a new BinaryReaderEx if necessary.
         /// </summary>
-        public static BinaryReaderEx GetDecompressedBinaryReader(BinaryReaderEx br, out DCX.Type compression)
+        public static BinaryReaderEx GetDecompressedBinaryReader(BinaryReaderEx br, out DCX.CompressionData compression)
         {
             if (DCX.Is(br))
             {
@@ -20,7 +20,7 @@ namespace SoulsFormats
             }
             else
             {
-                compression = DCX.Type.None;
+                compression = new DCX.CompressionData(DCX.Type.None);
                 return br;
             }
         }

--- a/SoulsFormats/Utilities/SFUtil.cs
+++ b/SoulsFormats/Utilities/SFUtil.cs
@@ -20,7 +20,7 @@ namespace SoulsFormats
             }
             else
             {
-                compression = new DCX.CompressionData(DCX.Type.None);
+                compression = new DCX.NoCompressionData();
                 return br;
             }
         }


### PR DESCRIPTION
Changes DCX-related functions to use a CompressionInfo struct instead of a Type enum.

This allows carrying certain metadata, such as CompressionLevel for KRAK and the various unknowns for DFLT.

This eliminates the need for "subtypes" such as KRAK_MAX or DCX_DFLT_11000_44_9 or whatever.

Another bonus is that the DCX DFLT formats become more robust against ""encryption technology"".

Problems:
- It may blow up the complexity of working with the classes.
- Probably some other design issues.