### PR TITLE
Fix incorrect namespace for FXR1 classes

### DIFF
--- a/SoulsFormats/Formats/FXR1/DS1RExtraParams.cs
+++ b/SoulsFormats/Formats/FXR1/DS1RExtraParams.cs
@@ -1,6 +1,4 @@
-﻿using SoulsFormats;
-
-namespace SoulsFormatsExtensions
+﻿namespace SoulsFormats
 {
     public partial class FXR1
     {

--- a/SoulsFormats/Formats/FXR1/FXAction.cs
+++ b/SoulsFormats/Formats/FXR1/FXAction.cs
@@ -1,7 +1,6 @@
-﻿using SoulsFormats;
-using System.Xml.Serialization;
+﻿using System.Xml.Serialization;
 
-namespace SoulsFormatsExtensions
+namespace SoulsFormats
 {
     public partial class FXR1
     {

--- a/SoulsFormats/Formats/FXR1/FXActionData.cs
+++ b/SoulsFormats/Formats/FXR1/FXActionData.cs
@@ -1,9 +1,8 @@
-﻿using SoulsFormats;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Xml.Serialization;
 
-namespace SoulsFormatsExtensions
+namespace SoulsFormats
 {
     public partial class FXR1
     {

--- a/SoulsFormats/Formats/FXR1/FXContainer.cs
+++ b/SoulsFormats/Formats/FXR1/FXContainer.cs
@@ -1,8 +1,7 @@
-﻿using SoulsFormats;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Xml.Serialization;
 
-namespace SoulsFormatsExtensions
+namespace SoulsFormats
 {
     public partial class FXR1
     {

--- a/SoulsFormats/Formats/FXR1/FXField.cs
+++ b/SoulsFormats/Formats/FXR1/FXField.cs
@@ -1,10 +1,9 @@
-﻿using SoulsFormats;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Xml;
 using System.Xml.Serialization;
 
-namespace SoulsFormatsExtensions
+namespace SoulsFormats
 {
     public partial class FXR1
     {

--- a/SoulsFormats/Formats/FXR1/FXModifier.cs
+++ b/SoulsFormats/Formats/FXR1/FXModifier.cs
@@ -1,8 +1,7 @@
-﻿using SoulsFormats;
-using System;
+﻿using System;
 using System.Xml.Serialization;
 
-namespace SoulsFormatsExtensions
+namespace SoulsFormats
 {
     public partial class FXR1
     {

--- a/SoulsFormats/Formats/FXR1/FXNode.cs
+++ b/SoulsFormats/Formats/FXR1/FXNode.cs
@@ -1,9 +1,8 @@
-﻿using SoulsFormats;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Xml.Serialization;
 
-namespace SoulsFormatsExtensions
+namespace SoulsFormats
 {
     public partial class FXR1
     {

--- a/SoulsFormats/Formats/FXR1/FXNodePointer.cs
+++ b/SoulsFormats/Formats/FXR1/FXNodePointer.cs
@@ -1,7 +1,6 @@
-﻿using SoulsFormats;
-using System.Xml.Serialization;
+﻿using System.Xml.Serialization;
 
-namespace SoulsFormatsExtensions
+namespace SoulsFormats
 {
     public partial class FXR1
     {

--- a/SoulsFormats/Formats/FXR1/FXR1.cs
+++ b/SoulsFormats/Formats/FXR1/FXR1.cs
@@ -1,12 +1,11 @@
-﻿using SoulsFormats;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml;
 using System.Xml.Serialization;
 
-namespace SoulsFormatsExtensions
+namespace SoulsFormats
 {
     public partial class FXR1 : SoulsFile<FXR1>
     {

--- a/SoulsFormats/Formats/FXR1/FXState.cs
+++ b/SoulsFormats/Formats/FXR1/FXState.cs
@@ -1,8 +1,7 @@
-﻿using SoulsFormats;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Xml.Serialization;
 
-namespace SoulsFormatsExtensions
+namespace SoulsFormats
 {
     public partial class FXR1
     {

--- a/SoulsFormats/Formats/FXR1/FXTransition.cs
+++ b/SoulsFormats/Formats/FXR1/FXTransition.cs
@@ -1,7 +1,6 @@
-﻿using SoulsFormats;
-using System.Xml.Serialization;
+﻿using System.Xml.Serialization;
 
-namespace SoulsFormatsExtensions
+namespace SoulsFormats
 {
     public partial class FXR1
     {

--- a/SoulsFormats/Formats/FXR1/FxrEnvironment.cs
+++ b/SoulsFormats/Formats/FXR1/FxrEnvironment.cs
@@ -1,9 +1,8 @@
-﻿using SoulsFormats;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace SoulsFormatsExtensions
+namespace SoulsFormats
 {
     public partial class FXR1
     {

--- a/SoulsFormats/Formats/FXR1/Ticks.cs
+++ b/SoulsFormats/Formats/FXR1/Ticks.cs
@@ -1,8 +1,7 @@
-﻿using SoulsFormats;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Xml.Serialization;
 
-namespace SoulsFormatsExtensions
+namespace SoulsFormats
 {
     public partial class FXR1
     {

--- a/SoulsFormats/Formats/FXR1/XIDable.cs
+++ b/SoulsFormats/Formats/FXR1/XIDable.cs
@@ -1,6 +1,6 @@
 ﻿using System.Xml.Serialization;
 
-namespace SoulsFormatsExtensions
+namespace SoulsFormats
 {
     public partial class FXR1
     {


### PR DESCRIPTION
Changes the namespace to Soulsformats and removes unnecessary usings